### PR TITLE
Fixed unit tests, added support for potential repeating partials caus…

### DIFF
--- a/robustredirects/middleware.py
+++ b/robustredirects/middleware.py
@@ -54,7 +54,7 @@ class RedirectMiddleware(object):
         redirect = Redirect.objects.filter(
             Q(from_url__iexact=no_leading_slash_path) | Q(from_url__iexact=leading_slash_path),
             status=1,
-            site=current_site).first()
+            site=current_site).order_by('-pk').first()
 
         if redirect:
             if redirect.to_url == '':

--- a/robustredirects/middleware.py
+++ b/robustredirects/middleware.py
@@ -51,12 +51,12 @@ class RedirectMiddleware(object):
             leading_slash_path = '/' + path
 
         # Try looking for an exact match
-        redirects = Redirect.objects.filter(
+        redirect = Redirect.objects.filter(
             Q(from_url__iexact=no_leading_slash_path) | Q(from_url__iexact=leading_slash_path),
             status=1,
-            site=current_site)
+            site=current_site).first()
 
-        for redirect in redirects:
+        if redirect:
             if redirect.to_url == '':
                 return HttpResponseGone()
 

--- a/robustredirects/utils.py
+++ b/robustredirects/utils.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 from django.conf import settings
 from models import Redirect
+from robustredirects import views
 
 
 def group_arguments(seq, group=254):
@@ -37,9 +38,9 @@ def get_redirect_patterns():
 
         if redirect.http_status == 302:
             extra.update({'permanent': False})
-            url_list.append(url(pattern, 'redirect_to', extra))
+            url_list.append(url(pattern, views.redirect_to, extra))
         else:
-            url_list.append(url(pattern, 'redirect_to', extra))
+            url_list.append(url(pattern, views.redirect_to, extra))
 
     arg_groups = list(group_arguments(url_list))
     for args in arg_groups:

--- a/robustredirects/views.py
+++ b/robustredirects/views.py
@@ -1,7 +1,8 @@
 # view patterns
+import logging
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect, HttpResponseGone
-from django.utils.log import getLogger
-logger = getLogger('django.request')
+
+logger = logging.getLogger('django.request')
 
 
 def redirect_to(request, url, permanent=True, query_string=False, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ from setuptools import setup
 
 setup(
     name="django-robust-redirects",
-    version="0.9.3",
+    version="0.9.4",
     url='http://github.com/spothero/django-robust-redirects',
-    download_url='http://github.com/spothero/django-robust-redirects/tarball/0.9.3',
+    download_url='http://github.com/spothero/django-robust-redirects/tarball/0.9.4',
     description="A more robust and feature full django redirect package",
     author='SpotHero and Glen Zangirolami',
     author_email='cezar@spothero.com',


### PR DESCRIPTION
…ing url part repretition

Added support for the case when the same partial root is in the redirects table:

Example:
Entry 1:
```
from_url                                                             
/sears-tower---willis-tower-parking
to_url 
/chicago/sears-tower-willis-tower-parking
```
Entry 2
```
from_url                                                             
/chicago/sears-tower---willis-tower-parking
to_url 
/chicago/sears-tower-willis-tower-parking
```

A request to /chicago/sears-tower---willis-tower-parking would redirect to /chicago/chicago/sears-tower---willis-tower-parking
