### PR TITLE
Add quick-look history for redirect admin page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ django_redirect.egg-info
 
 # except for .gitignore
 !.gitignore
+
+/redirecttest/test

--- a/redirecttest/redirecttest/__init__.py
+++ b/redirecttest/redirecttest/__init__.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+dirname = os.path.dirname(__file__)
+sys.path.insert(0, os.path.realpath(os.path.join(dirname, '../..')))

--- a/robustredirects/admin.py
+++ b/robustredirects/admin.py
@@ -63,5 +63,10 @@ class RedirectAdmin(admin.ModelAdmin):
             "time": log.action_time.strftime("%Y-%m-%d %H:%M %Z"),
         } for log in self.logs()[:20]]
 
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["history"] = self.history
+        return super(RedirectAdmin, self).changelist_view(request, extra_context)
+
 
 admin.site.register(Redirect, RedirectAdmin)

--- a/robustredirects/templates/change_form.html
+++ b/robustredirects/templates/change_form.html
@@ -63,7 +63,7 @@
             </thead>
 
             <tbody>
-            {% for entry in cl.model_admin.history %}
+            {% for entry in history %}
             <tr>
                 <td><a href="{{ request.path }}{{ entry.id }}">{{ entry.description }}</a></td>
                 <td>{{ entry.user }}</td>
@@ -72,7 +72,7 @@
             {% endfor %}
             </tbody>
         </table>
-        <p class="paginator">Most recent {{ cl.model_admin.history | length }} action(s)</p>
+        <p class="paginator">Most recent {{ history | length }} action(s)</p>
     </div>
 </div>
 {% endblock %}

--- a/robustredirects/templates/change_form.html
+++ b/robustredirects/templates/change_form.html
@@ -1,0 +1,78 @@
+{% extends 'admin/change_list.html' %}
+
+{% block extrastyle %}
+{{ block.super }}
+
+<style>
+    #history table {
+        width: 100%
+    }
+
+    #history #title {
+        background-color: #999;
+        color: white;
+        padding: 0.5rem;
+        border: none;
+        border-radius: 0.5rem;
+        margin-bottom: 1rem;
+    }
+
+    #history #title:hover {
+        background-color: #777;
+    }
+
+    #history .paginator {
+        color: #666;
+        padding-left: 0.5rem;
+    }
+
+    .hidden {
+        display: none;
+    }
+</style>
+{% endblock %}
+
+{% block extrahead %}
+{{ block.super }}
+
+<script type="text/javascript">
+    var $ = django.jQuery;
+
+    $(document).ready(function () {
+        $("#history #title").click(function () {
+            $("#history #table").toggle("hidden");
+        });
+    });
+</script>
+{% endblock %}
+
+{% block content %}
+{{ block.super }}
+
+<div id="history">
+    <button id="title">History</button>
+
+    <div id="table" class="hidden">
+        <table>
+            <thead>
+            <tr>
+                <th>Action</th>
+                <th>User</th>
+                <th>Time</th>
+            </tr>
+            </thead>
+
+            <tbody>
+            {% for entry in cl.model_admin.history %}
+            <tr>
+                <td><a href="{{ request.path }}{{ entry.id }}">{{ entry.description }}</a></td>
+                <td>{{ entry.user }}</td>
+                <td>{{ entry.time }}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        <p class="paginator">Most recent {{ cl.model_admin.history | length }} action(s)</p>
+    </div>
+</div>
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="django-robust-redirects",
-    version="0.13.0",
+    version="0.13.1",
     url="http://github.com/spothero/django-robust-redirects",
     download_url="http://github.com/spothero/django-robust-redirects/tarball/0.10.0",
     description="A more robust and feature full django redirect package",


### PR DESCRIPTION
Users of the admin page want to see "edit history" information for redirects on the 'redirects' page
- Adds an 'edit' column that shows the date/time and user of last edit to that row
- Adds history view at bottom of page that displays most recent changes