### PR TITLE
Upgrade to support Django 2.x.

### DIFF
--- a/redirecttest/redirecttest/settings.py
+++ b/redirecttest/redirecttest/settings.py
@@ -84,7 +84,7 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '9#7ts=7ql%wda*pxoa5s94!-o*u$v0vz=vg6*_&%av067#%@j5'
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/redirecttest/redirecttest/urls.py
+++ b/redirecttest/redirecttest/urls.py
@@ -15,5 +15,5 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'^partialtest/(?P<pk>\d+)/', TestView.as_view()),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/redirecttest/requirements.txt
+++ b/redirecttest/requirements.txt
@@ -1,2 +1,4 @@
-Django>=1.10.3,<2
-django-nose>=1.4.3
+Django>=1.11,<3
+django-nose>=1.4.6
+future>=0.17.1,<1
+six>=1.12.0,<2

--- a/redirecttest/requirements.txt
+++ b/redirecttest/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.11,<3
+Django>=1.10.3,<3
 django-nose>=1.4.6
 future>=0.17.1,<1
 six>=1.12.0,<2

--- a/robustredirects/admin.py
+++ b/robustredirects/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import clear_url_caches
+from django.urls import clear_url_caches
 from six.moves import reload_module
 
 from robustredirects.models import Redirect

--- a/robustredirects/middleware.py
+++ b/robustredirects/middleware.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import resolve, Resolver404
+from django.urls import resolve, Resolver404
 from django.db.models import Q
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect, HttpResponseGone
 from robustredirects.models import Redirect

--- a/robustredirects/models.py
+++ b/robustredirects/models.py
@@ -31,7 +31,7 @@ is_partial_helptext = _('The From and To URL are partial. They will be used if t
 
 
 class Redirect(models.Model):
-    site = models.ForeignKey(Site, related_name='robust_redirects')
+    site = models.ForeignKey(Site, on_delete=models.CASCADE, related_name='robust_redirects')
 
     from_url = models.CharField(_('From URL'), max_length=255, unique=True,
                                 db_index=True, help_text=from_url_helptext)

--- a/robustredirects/tests.py
+++ b/robustredirects/tests.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseNotFound
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import clear_url_caches
+from django.urls import clear_url_caches
 
 from robustredirects.middleware import RedirectMiddleware
 from robustredirects.models import Redirect
@@ -43,7 +43,7 @@ class TestRedirectMiddleWare(TestCase):
         new_response = self.run_redirect(request)
 
         self.assertEqual(new_response.status_code, 301)
-        assert 'somethingelse' in new_response.serialize_headers()
+        self.assertIn(b"somethingelse", new_response.serialize_headers())
 
     def test_redirect_request_gone(self):
         # Create a redirect
@@ -68,7 +68,7 @@ class TestRedirectMiddleWare(TestCase):
         new_response = self.run_redirect(request)
 
         self.assertEqual(new_response.status_code, 302)
-        assert 'somethingelse' in new_response.serialize_headers()
+        self.assertIn(b"somethingelse", new_response.serialize_headers())
 
     def test_redirect_request_partial_temporary(self):
         # Create a redirect
@@ -81,7 +81,7 @@ class TestRedirectMiddleWare(TestCase):
         new_response = self.run_redirect(request)
 
         self.assertEqual(new_response.status_code, 302)
-        assert 'partialtest' in new_response.serialize_headers()
+        self.assertIn(b"partialtest", new_response.serialize_headers())
 
     def test_redirect_request_partial_permanent(self):
         # Create a redirect
@@ -94,7 +94,7 @@ class TestRedirectMiddleWare(TestCase):
         new_response = self.run_redirect(request)
 
         self.assertEqual(new_response.status_code, 301)
-        assert 'partialtest' in new_response.serialize_headers()
+        self.assertIn(b"partialtest", new_response.serialize_headers())
 
     def test_redirect_request_two_partial_entries_permanent(self):
         # Create a redirect
@@ -138,7 +138,7 @@ class TestRedirectMiddleWare(TestCase):
         new_response = self.run_redirect(request)
 
         self.assertEqual(new_response.status_code, 302)
-        assert '/partialtest/123/' in new_response.serialize_headers()
+        self.assertIn(b"/partialtest/123/", new_response.serialize_headers())
 
     def test_redirect_exclusion(self):
         # Create a redirect

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=[
-        "django>=1.10.3,<2",
+        "django>=1.11,<3",
         "future>=0.17.1,<1",
         "six>=1.12.0,<2"
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="django-robust-redirects",
-    version="0.13.2",
+    version="0.13.3",
     url="http://github.com/spothero/django-robust-redirects",
     download_url="http://github.com/spothero/django-robust-redirects/tarball/0.10.0",
     description="A more robust and feature full django redirect package",
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python",
     ],
     install_requires=[
-        "django>=1.11,<3",
+        "django>=1.10.3,<3",
         "future>=0.17.1,<1",
         "six>=1.12.0,<2"
     ],


### PR DESCRIPTION
Update to support Django 2.x.

There are 2 categories of changs.
- Changes in `redirecttest` to support testing of `robustredirects`.  Most of the changes in this PR are here.
- Changes in `robustredirects`. This is actual library that I'd like updated to support Django 2.x.